### PR TITLE
fix whiteout opaque prefix

### DIFF
--- a/src/container_inspector/rootfs.py
+++ b/src/container_inspector/rootfs.py
@@ -100,7 +100,7 @@ def rebuild_rootfs(img, target_dir):
 
 
 WHITEOUT_EXPLICIT_PREFIX = '.wh.'
-WHITEOUT_OPAQUE_PREFIX = '.wh..wh.opq'
+WHITEOUT_OPAQUE_PREFIX = '.wh..wh..opq'
 
 
 def is_whiteout_marker(path):


### PR DESCRIPTION
Per - https://github.com/opencontainers/image-spec/blob/main/layer.md#whiteouts
An opaque whiteout entry is a file with the name `.wh..wh..opq` but code is currently missing the second second dot