### PR TITLE
setup.cfg: fix invalid version spec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ zip_safe = false
 
 setup_requires = setuptools_scm[toml] >= 4
 
-python_requires = >=3.7.*
+python_requires = >=3.7
 
 install_requires =
     click >= 6.7, !=7.0, !=8.0.3


### PR DESCRIPTION
after PEP440 support has been removed in newer setuptools (v66+) this would otherwise result in an error like setuptools.extern.packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=3.7.*'

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>